### PR TITLE
Add Ints reply helper function

### DIFF
--- a/redis/reply.go
+++ b/redis/reply.go
@@ -270,3 +270,20 @@ func Strings(reply interface{}, err error) ([]string, error) {
 	}
 	return nil, fmt.Errorf("redigo: unexpected type for Strings, got type %T", reply)
 }
+
+// Ints is a helper that converts an array command reply to a []int. If
+// err is not equal to nil, then Ints returns nil, err.
+func Ints(reply interface{}, err error) ([]int, error) {
+	var ints []int
+	if reply == nil {
+		return ints, ErrNil
+	}
+	values, err := Values(reply, err)
+	if err != nil {
+		return ints, err
+	}
+	if err := ScanSlice(values, &ints); err != nil {
+		return ints, err
+	}
+	return ints, nil
+}

--- a/redis/reply_test.go
+++ b/redis/reply_test.go
@@ -38,6 +38,16 @@ var replyTests = []struct {
 	expected valueError
 }{
 	{
+		"ints([v1, v2])",
+		ve(redis.Ints([]interface{}{[]byte("4"), []byte("5")}, nil)),
+		ve([]int{4, 5}, nil),
+	},
+	{
+		"ints(nil)",
+		ve(redis.Ints(nil, nil)),
+		ve([]int(nil), redis.ErrNil),
+	},
+	{
 		"strings([v1, v2])",
 		ve(redis.Strings([]interface{}{[]byte("v1"), []byte("v2")}, nil)),
 		ve([]string{"v1", "v2"}, nil),
@@ -125,6 +135,20 @@ func ExampleInt() {
 	// Output:
 	// 1
 	// 2
+}
+
+func ExampleInts() {
+	c, err := dial()
+	if err != nil {
+		panic(err)
+	}
+	defer c.Close()
+
+	c.Do("SADD", "set_with_integers", 4, 5, 6)
+	ints, _ := redis.Ints(c.Do("SMEMBERS", "set_with_integers"))
+	fmt.Printf("%#v\n", ints)
+	// Output:
+	// []int{4, 5, 6}
 }
 
 func ExampleString() {


### PR DESCRIPTION
Hi, 

I suggest adding a helper function "Ints" to facilitate converting a the response interface to []int.
Example: 
    c, err := dial()
    if err != nil {
        panic(err)
    }
    defer c.Close()

    c.Do("SADD", "set_with_integers", 4, 5, 6)
    ints, _ := redis.Ints(c.Do("SMEMBERS", "set_with_integers"))
    fmt.Printf("%#v\n", ints)
    // Output:
    // []int{4, 5, 6}