### PR TITLE
Added support for Scanning []interface in a struct.

### DIFF
--- a/redis/scan.go
+++ b/redis/scan.go
@@ -101,6 +101,12 @@ func convertAssignValue(d reflect.Value, s interface{}) (err error) {
 		err = convertAssignBytes(d, s)
 	case int64:
 		err = convertAssignInt(d, s)
+	case []interface{}:
+		if d.Type().Elem().Kind() == reflect.Interface {
+			d.Set(reflect.ValueOf(s))
+			return nil
+		}
+		return convertAssignValues(d, s)
 	default:
 		err = cannotConvert(d, s)
 	}


### PR DESCRIPTION
When using ScanSlice, this change allows having a `[]interface` in a struct. Otherwise, it gives a message that seems like it should be wrong:

```
redigo: Scan cannot convert from []interface {} to []interface {}
```

I also added recursive slicing otherwise.