### PR TITLE
Support for redis sentinel

### DIFF
--- a/redis/pool.go
+++ b/redis/pool.go
@@ -334,9 +334,8 @@ type SentinelAwarePool struct {
 func (sap *SentinelAwarePool) UpdateMaster(addr string) {
   if addr != sap.masterAddr {
     sap.masterAddr = addr
-    go func() {
-      sap.closeAll()
-    }()
+    sap.closeAll()
+    }
   }
 }
 

--- a/redis/pool.go
+++ b/redis/pool.go
@@ -335,7 +335,6 @@ func (sap *SentinelAwarePool) UpdateMaster(addr string) {
   if addr != sap.masterAddr {
     sap.masterAddr = addr
     sap.closeAll()
-    }
   }
 }
 

--- a/redis/pool.go
+++ b/redis/pool.go
@@ -405,7 +405,6 @@ func (sap *SentinelAwarePool) testConn(c Conn) error {
 	err := c.Err()
 	if err != nil {
 		return err
-		i
 	}
 	return sap.TestOnReturn(c)
 }

--- a/redis/pool.go
+++ b/redis/pool.go
@@ -294,6 +294,31 @@ func (p *Pool) put(c Conn, forceClose bool) error {
 	return c.Close()
 }
 
+// The SentinelAwarePool is identical to the normal Pool implementation except
+// the configuration of the monitorered master is retained through a set of
+// methods. Change in this configuration causes a purge of all stored idle
+// connections. 
+// Example: TODO Flesh this out.
+// Dial -> should check master config, update it, then proceed to dial it or
+// DialSlave.
+type SentinelAwarePool struct {
+  Pool
+  MasterAddr string
+  Purge chan bool
+}
+
+func (sap *SentinelAwarePool) UpdateMaster(addr string) {
+  if addr != sap.MasterAddr {
+    sap.MasterAddr = addr
+    go func() {
+      // Once the lock opens up, purge all connections
+      sap.mu.Lock()
+    }
+  }
+}
+
+
+
 type pooledConnection struct {
 	p     *Pool
 	c     Conn

--- a/redis/pool.go
+++ b/redis/pool.go
@@ -165,7 +165,7 @@ func (p *Pool) ActiveCount() int {
 // Close releases the resources used by the pool.
 func (p *Pool) Close() error {
 	p.closed = true
-  p.closeAll()
+	p.closeAll()
 	return nil
 }
 
@@ -274,14 +274,13 @@ func (p *Pool) get() (Conn, error) {
 	}
 }
 
-
 func (p *Pool) put(c Conn, forceClose bool) error {
 	err := c.Err()
-  return p.putCommon(err, c, forceClose)
+	return p.putCommon(err, c, forceClose)
 }
 
-// putCommon contains operations in common with the Pool and the 
-// SentinelAwarePool. 
+// putCommon contains operations in common with the Pool and the
+// SentinelAwarePool.
 func (p *Pool) putCommon(err error, c Conn, forceClose bool) error {
 	p.mu.Lock()
 	if !p.closed && err == nil && !forceClose {
@@ -307,32 +306,32 @@ func (p *Pool) putCommon(err error, c Conn, forceClose bool) error {
 }
 
 // The SentinelAwarePool is identical to the normal Pool implementation except
-// the configuration of the monitored master is retained. Change in this 
+// the configuration of the monitored master is retained. Change in this
 // configuration causes a purge of all stored idle connections. The typical
 // use of the UpdateMaster method will be in the Dial() method, see the
 // example below.
 //
 // A TestOnReturn function entry point is also supplied. Users are encouraged
-// to put a role test in TestOnReturn to prevent connections that persist 
+// to put a role test in TestOnReturn to prevent connections that persist
 // through unexpected role changes without fatal errors from making it back
 // into the pool.
 //
 // Active connections will not be impacted by the purge. The user is expected
-// to be aware of this and be able to handle interruptions to the redis 
+// to be aware of this and be able to handle interruptions to the redis
 // connection in the event of a failover, which is _not_ seamless.
 //
 // Example of usage to contact master:
 //
 //  func newSentinelPool() *redis.SentinelAwarePool {
-//	  sentConn, err := redis.NewSentinelClient("tcp", 
-//      []string{"127.0.0.1:26379", "127.0.0.2:26379", "127.0.0.2.26379"}, 
+//	  sentConn, err := redis.NewSentinelClient("tcp",
+//      []string{"127.0.0.1:26379", "127.0.0.2:26379", "127.0.0.2.26379"},
 //      nil, 100*time.Millisecond, 100*time.Millisecond, 100*time.Millisecond)
-//	
+//
 //	  if err != nil {
 //	    log.Println("Failed to connect to redis sentinel:", err)
 //	    return nil
 //	  }
-//	
+//
 //	  sap := &redis.SentinelAwarePool{
 //	    Pool : redis.Pool{
 //	      MaxIdle : 10,
@@ -353,7 +352,7 @@ func (p *Pool) putCommon(err error, c Conn, forceClose bool) error {
 //	      }
 //	    },
 //	  }
-//	
+//
 //	  sap.Pool.Dial = func() (redis.Conn, error) {
 //	    masterAddr, err := sentConn.QueryConfForMaster("kvmaster")
 //	    if err != nil {
@@ -370,56 +369,56 @@ func (p *Pool) putCommon(err error, c Conn, forceClose bool) error {
 //	    }
 //	    return c, err
 //	  }
-//	
+//
 //	  return sap
 //	}
-//	
-// The SentinelClient used above will try all connected sentinels when 
+//
+// The SentinelClient used above will try all connected sentinels when
 // querying for the master address. However, if no sentinels can be
 // contacted, it may be impossible to dial for some time. The
 // SentinelClient should automatically recover once a sentinel returns.
 type SentinelAwarePool struct {
-  Pool
-  // TestOnReturn is a user-supplied function to test a connection before
-  // returning it to the pool. Like TestOnBorrow, TestOnReturn will close the
-  // connection if an error is observed. It is strongly suggested to test the
-  // role of a connection on return, especially if the sentinels in use are
-  // older than 2.8.12.
-  TestOnReturn func(c Conn) error
+	Pool
+	// TestOnReturn is a user-supplied function to test a connection before
+	// returning it to the pool. Like TestOnBorrow, TestOnReturn will close the
+	// connection if an error is observed. It is strongly suggested to test the
+	// role of a connection on return, especially if the sentinels in use are
+	// older than 2.8.12.
+	TestOnReturn func(c Conn) error
 
-  masterAddr string
+	masterAddr string
 }
 
 // UpdateMaster updates the internal accounting of the SentinelAwarePool,
-// which may trigger a flush of all idle connections if the master 
-// changes. 
+// which may trigger a flush of all idle connections if the master
+// changes.
 func (sap *SentinelAwarePool) UpdateMaster(addr string) {
-  if addr != sap.masterAddr {
-    sap.masterAddr = addr
-    sap.closeAll()
-  }
+	if addr != sap.masterAddr {
+		sap.masterAddr = addr
+		sap.closeAll()
+	}
 }
 
 // Entrypoint for TestOnReturn, any error here causes the connection to be
 // closed instead of being returned to the pool.
 func (sap *SentinelAwarePool) testConn(c Conn) error {
-  err := c.Err()
-  if err != nil {
-    return err
-i
-  }
-  return sap.TestOnReturn(c)
+	err := c.Err()
+	if err != nil {
+		return err
+		i
+	}
+	return sap.TestOnReturn(c)
 }
 
 func (sap *SentinelAwarePool) put(c Conn, forceClose bool) error {
 	err := sap.testConn(c)
-  return sap.putCommon(err, c, forceClose)
+	return sap.putCommon(err, c, forceClose)
 }
 
 // New interface to allow the pooledConnection to interact with both
 // the Pool and the SentinelAwarePool.
 type connToPool interface {
-  put (Conn, bool) error
+	put(Conn, bool) error
 }
 
 type pooledConnection struct {
@@ -444,7 +443,6 @@ func initSentinel() {
 		sentinel = h.Sum(nil)
 	}
 }
-
 
 func (pc *pooledConnection) Close() error {
 	c := pc.c

--- a/redis/sentinel.go
+++ b/redis/sentinel.go
@@ -241,7 +241,7 @@ func GetRole(c Conn) (string, error) {
 func GetReplicationRole(c Conn) (string, error) {
   res, err := String(c.Do("INFO", "replication"))
   if err == nil {
-    sres := strings.Split(res, "\n")
+    sres := strings.Split(res, "\r\n")
     for _,s := range(sres) {
       si := strings.Split(s,":")
       if si[0] == "role" {

--- a/redis/sentinel.go
+++ b/redis/sentinel.go
@@ -307,7 +307,7 @@ func GetReplicationRole(c Conn) (string, error) {
 }
 
 // TestRole wraps GetRole in a test to verify if the role matches an expected 
-// role string. If there was any error in querying the supplied connection, o
+// role string. If there was any error in querying the supplied connection, 
 // the function returns false.
 func TestRole(c Conn, expectedRole string) bool {
   role, err := GetRole(c)

--- a/redis/sentinel.go
+++ b/redis/sentinel.go
@@ -117,7 +117,7 @@ func (sc *SentinelClient) do(addrs []string, cmd string, args ...interface{}) (i
   res, err := sc.Conn.Do(cmd, args...)
   if err != nil && res == nil { // indicates connection error of some sort
     sc.Conn.Close()
-    err, leftovers = sc.dial(addrs)
+    err, leftovers := sc.dial(addrs)
     if err != nil {
       return nil, err
     } else {

--- a/redis/sentinel.go
+++ b/redis/sentinel.go
@@ -157,7 +157,7 @@ func (sc *SentinelClient) QueryConfForSlaves(name string) ([]map[string]string, 
 
 // A convenience function which formats only the relevant parts of a single slave
 // map[string]string into an address ip:port pair.
-func SlaveAddr(slaveMap map[string]string) {
+func SlaveAddr(slaveMap map[string]string) string {
   return fmt.Sprintf("%s:%s", slaveMap["ip"], slaveMap["port"])
 }
 

--- a/redis/sentinel.go
+++ b/redis/sentinel.go
@@ -94,8 +94,9 @@ func (sc *SentinelClient) Dial() error {
 
 func (sc *SentinelClient) dial(addrs []string) (error, []string) {
 	var lastErr error
+	var subSentList []string = make([]string, len(addrs))
 
-	for subSentList := addrs; len(subSentList) > 0; {
+	for copy(subSentList, addrs); len(subSentList) > 0; {
 		i := sc.ElectSentinel(subSentList)
 		addr := subSentList[i]
 		subSentList = append(subSentList[:i], subSentList[i+1:]...)

--- a/redis/sentinel.go
+++ b/redis/sentinel.go
@@ -227,11 +227,12 @@ func (sc *SentinelClient) DialSlave(name string) (Conn, error) {
 // changes.
 func GetRole(c Conn) (string, error) {
   res, err := c.Do("ROLE")
-  if err != nil || len(res) == 0 {
-    return GetReplicationRole(c)
-  } else {
-    return String(res[0]), nil
+
+  rres, ok := res.([]interface{})
+  if err == nil && ok {
+    return String(rres[0], nil)
   }
+  return GetReplicationRole(c)
 }
 
 // Queries the role of a connected redis instance by checking the output of the

--- a/redis/sentinel.go
+++ b/redis/sentinel.go
@@ -137,6 +137,40 @@ func (sc *SentinelClient) QueryConfForMaster(name string) (string, error) {
   return masterAddr, err
 }
 
+type SlaveDef struct {
+  Name  string
+  IP    string
+  Port  uint16
+  Runid string
+  Flags string
+  PendingCommands int
+  LastPingSent  int
+  LastOkPingReply int
+  LastPingReply int
+  DownAfterMilliseconds int
+  InfoRefresh int
+  RoleReported string
+  RoleReportedTime int
+  MasterLinkDownTime int
+  MasterLinkStatus string
+  MasterHost string
+  MasterPort uint16
+  SlavePriority int
+  SlaveReplOffset int
+}
+
+// QueryConfForSlaves looks up the configuration for a named monitored instance set
+// and returns all the slaves.
+func (sc *SentinelClient) QueryConfForSlaves(name string) ([]SlaveDef, error) {
+  res, err := sc.Do("SENTINEL", "slaves", name)
+  if err != nil {
+    return nil, err
+  }
+  var slaves []SlaveDef
+  err = ScanSlice(res.([]interface{}), slaves)
+  return slaves, err
+}
+
 // DialMaster returns a connection to the master of the named monitored instance set
 // Assumes the same network will be used to contact the master as the one used for
 // contacting the sentinels.
@@ -149,3 +183,7 @@ func (sc *SentinelClient) DialMaster(name string) (Conn, error) {
 
   return Dial(sc.net, masterAddr)
 }
+
+// DialSlave returns a connection to any slave of the named monitored instance set.
+//func (sc *SentinelClient) DialSlave(name string) (Conn, error) {
+//}

--- a/redis/sentinel.go
+++ b/redis/sentinel.go
@@ -137,37 +137,21 @@ func (sc *SentinelClient) QueryConfForMaster(name string) (string, error) {
   return masterAddr, err
 }
 
-type SlaveDef struct {
-  Name  string
-  IP    string
-  Port  uint16
-  Runid string
-  Flags string
-  PendingCommands int
-  LastPingSent  int
-  LastOkPingReply int
-  LastPingReply int
-  DownAfterMilliseconds int
-  InfoRefresh int
-  RoleReported string
-  RoleReportedTime int
-  MasterLinkDownTime int
-  MasterLinkStatus string
-  MasterHost string
-  MasterPort uint16
-  SlavePriority int
-  SlaveReplOffset int
-}
-
 // QueryConfForSlaves looks up the configuration for a named monitored instance set
 // and returns all the slaves.
-func (sc *SentinelClient) QueryConfForSlaves(name string) ([]SlaveDef, error) {
-  res, err := sc.Do("SENTINEL", "slaves", name)
+func (sc *SentinelClient) QueryConfForSlaves(name string) ([]map[string]string, error) {
+  res, err := Values(sc.Do("SENTINEL", "slaves", name))
   if err != nil {
     return nil, err
   }
-  var slaves []SlaveDef
-  err = ScanSlice(res.([]interface{}), slaves)
+  slaves := make([]map[string]string, 0)
+  for _,a := range(res) {
+    sm, err := StringMap(a, err)
+    if err != nil {
+      return slaves, err
+    }
+    slaves = append(slaves, sm)
+  }
   return slaves, err
 }
 

--- a/redis/sentinel.go
+++ b/redis/sentinel.go
@@ -226,11 +226,11 @@ func (sc *SentinelClient) DialSlave(name string) (Conn, error) {
 // the pool) should involve periodic role testing to protect against unexpected
 // changes.
 func GetRole(c Conn) (string, error) {
-  res, err := Strings(c.Do("ROLE"))
+  res, err := c.Do("ROLE")
   if err != nil || len(res) == 0 {
     return GetReplicationRole(c)
   } else {
-    return res[0], nil
+    return String(res[0]), nil
   }
 }
 
@@ -238,9 +238,10 @@ func GetRole(c Conn) (string, error) {
 // INFO replication section. GetRole should be used if the redis instance
 // is sufficiently new to support it.
 func GetReplicationRole(c Conn) (string, error) {
-  res, err := Strings(c.Do("INFO", "replication"))
+  res, err := String(c.Do("INFO", "replication"))
   if err == nil {
-    for _,s := range(res) {
+    sres := strings.Split(res, "\n")
+    for _,s := range(sres) {
       si := strings.Split(s,":")
       if si[0] == "role" {
         return si[1], nil

--- a/redis/sentinel.go
+++ b/redis/sentinel.go
@@ -198,10 +198,12 @@ func (sc *SentinelClient) DialSlave(name string) (Conn, error) {
     index := rand.Int31n(int32(len(slaves)))
     flags := SlaveReadFlags(slaves[index])
     if slaves[index]["master-link-status"] == "ok" && !(flags["disconnected"] || flags["sdown"] || flags["odown"]){
-      return Dial(sc.net, SlaveAddr(slaves[index]))
-    } else {
-      slaves = append(slaves[:index], slaves[index+1:]...)
+      conn, err := Dial(sc.net, SlaveAddr(slaves[index]))
+      if err == nil {
+        return conn, err
+      }
     }
+    slaves = append(slaves[:index], slaves[index+1:]...)
   }
   return nil, errors.New("No connected slaves with active master-link available")
 }

--- a/redis/sentinel.go
+++ b/redis/sentinel.go
@@ -131,6 +131,6 @@ func (sc *SentinelClient) do(addrs []string, cmd string, args ...interface{}) (i
 // QueryConfForMaster looks up the configuration for a named monitored instance set
 // and returns the master's configuration.
 func (sc *SentinelClient) QueryConfForMaster(name string) (string, error) {
-  res, err := String(sc.Do("SENTINEL", "get-master-addr-by-name", name))
+  res, err := Strings(sc.Do("SENTINEL", "get-master-addr-by-name", name))
   return res, err
 }

--- a/redis/sentinel.go
+++ b/redis/sentinel.go
@@ -69,7 +69,11 @@ type NoSentinelsLeft struct {
 }
 
 func (ns NoSentinelsLeft) Error() string {
-  return fmt.Sprintf("redigo: no configured sentinels successfully connected; last error: %s", ns.lastError.Error())
+  if ns.lastError != nil {
+    return fmt.Sprintf("redigo: no configured sentinels successfully connected; last error: %s", ns.lastError.Error())
+  } else {
+    return fmt.Sprintf("redigo: no configured sentinels successfully connected.")
+  }
 }
 
 // Dial connects to the sentinel, NOT the members of a monitored instance 
@@ -98,6 +102,7 @@ func (sc *SentinelClient) dial(addrs []string) (error, []string) {
       sc.Conn = conn
       return nil, subSentList
     }
+    lastError = err
   }
 
   return NoSentinelsLeft{lastError : lastErr}, []string{}

--- a/redis/sentinel.go
+++ b/redis/sentinel.go
@@ -1,122 +1,121 @@
 package redis
 
 import (
-  "errors"
-  "fmt"
-  "math/rand"
-  "time"
-  "strings"
+	"errors"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
 )
 
 type SentinelClient struct {
-  SentinelAddrs []string
-  net string
-  Conn Conn
-  ElectSentinel func([]string) (int)
-  connectTimeout time.Duration
-  readTimeout time.Duration
-  writeTimeout time.Duration
-  remainingAddrs []string
+	SentinelAddrs  []string
+	net            string
+	Conn           Conn
+	ElectSentinel  func([]string) int
+	connectTimeout time.Duration
+	readTimeout    time.Duration
+	writeTimeout   time.Duration
+	remainingAddrs []string
 }
 
-// Returns a SentinelClient with an active connection to at least 
+// Returns a SentinelClient with an active connection to at least
 // one currently active master.
-// 
+//
 // ElectSentinel expects a function that dictates the behavior for dialing
 // (see ElectSentinel, below). If nil, the sentinel will use a simple
 // fallback scheme, trying each address until one works.
-// 
+//
 // As per the redis-sentinel client guidelines, a timeout is mandatory
 // while connecting to sentinels, and should not be set to 0.
-// 
+//
 // Note that in a worst-case scenario, the timeout for performing an
 // operation with a SentinelClient wrapper method may take (# sentinels) *
 // timeout to test and connect to the various configured addresses.
 func NewSentinelClient(net string, addrs []string, electSentinel func([]string) int,
-  connectTimeout, readTimeout, writeTimeout time.Duration) (*SentinelClient, error) {
-  if electSentinel == nil {
-    electSentinel = fallbackElectSentinel
-  }
-  sc := &SentinelClient{
-    net : net,
-    SentinelAddrs : addrs,
-    ElectSentinel : electSentinel,
-    connectTimeout : connectTimeout,
-    readTimeout : readTimeout,
-    writeTimeout : writeTimeout,
-    remainingAddrs : make([]string, 0),
-  }
+	connectTimeout, readTimeout, writeTimeout time.Duration) (*SentinelClient, error) {
+	if electSentinel == nil {
+		electSentinel = fallbackElectSentinel
+	}
+	sc := &SentinelClient{
+		net:            net,
+		SentinelAddrs:  addrs,
+		ElectSentinel:  electSentinel,
+		connectTimeout: connectTimeout,
+		readTimeout:    readTimeout,
+		writeTimeout:   writeTimeout,
+		remainingAddrs: make([]string, 0),
+	}
 
-  err := sc.Dial()
+	err := sc.Dial()
 
-  return sc, err
+	return sc, err
 }
 
 // The default ElectSentinel implementation, just elects the first sentinel
 // in the list every time.
 func fallbackElectSentinel(addrs []string) int {
-  return 0
+	return 0
 }
 
 // For convenience, a purely random ElectSentinel implementation.
 func RandomElectSentinel(addrs []string) int {
-  return int(rand.Int31n(int32(len(addrs))))
+	return int(rand.Int31n(int32(len(addrs))))
 }
 
-
-// NoSentinelsLeft is returned when all sentinels in the list are exhausted 
+// NoSentinelsLeft is returned when all sentinels in the list are exhausted
 // (or none configured), and contains the last error returned by Dial (which
 // may be nil)
 type NoSentinelsLeft struct {
-  lastError error
+	lastError error
 }
 
 func (ns NoSentinelsLeft) Error() string {
-  if ns.lastError != nil {
-    return fmt.Sprintf("redigo: no configured sentinels successfully connected; last error: %s", ns.lastError.Error())
-  } else {
-    return fmt.Sprintf("redigo: no configured sentinels successfully connected.")
-  }
+	if ns.lastError != nil {
+		return fmt.Sprintf("redigo: no configured sentinels successfully connected; last error: %s", ns.lastError.Error())
+	} else {
+		return fmt.Sprintf("redigo: no configured sentinels successfully connected.")
+	}
 }
 
-// Dial connects to the sentinel, NOT the members of a monitored instance 
-// group. You can lookup the configuration of any named instance group after 
-// dial or use one of the convenience methods to obtain a connection to the 
+// Dial connects to the sentinel, NOT the members of a monitored instance
+// group. You can lookup the configuration of any named instance group after
+// dial or use one of the convenience methods to obtain a connection to the
 // redis instances.
 func (sc *SentinelClient) Dial() error {
-  if sc.SentinelAddrs == nil {
-    return errors.New("No configured sentinel addresses")
-  }
+	if sc.SentinelAddrs == nil {
+		return errors.New("No configured sentinel addresses")
+	}
 
-  err, leftovers := sc.dial(sc.SentinelAddrs)
-  sc.remainingAddrs = leftovers
-  return err
+	err, leftovers := sc.dial(sc.SentinelAddrs)
+	sc.remainingAddrs = leftovers
+	return err
 }
 
 func (sc *SentinelClient) dial(addrs []string) (error, []string) {
-  var lastErr error
+	var lastErr error
 
-  for subSentList := addrs; len(subSentList) > 0; {
-    i := sc.ElectSentinel(subSentList)
-    addr := subSentList[i]
-    subSentList = append(subSentList[:i], subSentList[i+1:]...)
-    conn, err := DialTimeout(sc.net, addr, sc.connectTimeout, sc.readTimeout,
-      sc.writeTimeout)
-    if err == nil {
-      sc.Conn = conn
-      return nil, subSentList
-    }
-    lastErr = err
-  }
+	for subSentList := addrs; len(subSentList) > 0; {
+		i := sc.ElectSentinel(subSentList)
+		addr := subSentList[i]
+		subSentList = append(subSentList[:i], subSentList[i+1:]...)
+		conn, err := DialTimeout(sc.net, addr, sc.connectTimeout, sc.readTimeout,
+			sc.writeTimeout)
+		if err == nil {
+			sc.Conn = conn
+			return nil, subSentList
+		}
+		lastErr = err
+	}
 
-  return NoSentinelsLeft{lastError : lastErr}, []string{}
+	return NoSentinelsLeft{lastError: lastErr}, []string{}
 }
 
-// Do is the entry point to the recursive do(), and performs the requested 
+// Do is the entry point to the recursive do(), and performs the requested
 // command on the currently connected sentinel, trying all other configured
-// sentinels until the list is exhausted. 
+// sentinels until the list is exhausted.
 func (sc *SentinelClient) Do(cmd string, args ...interface{}) (interface{}, error) {
-  return sc.do(sc.SentinelAddrs, cmd, args...)
+	return sc.do(sc.SentinelAddrs, cmd, args...)
 }
 
 // A wrapped version of the underlying conn.Do that attempts to restablish
@@ -124,140 +123,140 @@ func (sc *SentinelClient) Do(cmd string, args ...interface{}) (interface{}, erro
 // been tried. Note that the most likely scenario is that dial() will exhaust
 // sentinels until a working one is found.
 func (sc *SentinelClient) do(addrs []string, cmd string, args ...interface{}) (interface{}, error) {
-  res, err := sc.Conn.Do(cmd, args...)
-  if err != nil && res == nil { // indicates connection error of some sort
-    sc.Conn.Close()
-    err, leftovers := sc.dial(addrs)
-    if err != nil {
-      return nil, err
-    } else {
-      return sc.do(leftovers, cmd, args...)
-    }
-  } else {
-    return res, err
-  }
+	res, err := sc.Conn.Do(cmd, args...)
+	if err != nil && res == nil { // indicates connection error of some sort
+		sc.Conn.Close()
+		err, leftovers := sc.dial(addrs)
+		if err != nil {
+			return nil, err
+		} else {
+			return sc.do(leftovers, cmd, args...)
+		}
+	} else {
+		return res, err
+	}
 }
 
 // QueryConfForMaster looks up the configuration for a named monitored instance
 // set and returns the master's configuration.
 func (sc *SentinelClient) QueryConfForMaster(name string) (string, error) {
-  res, err := Strings(sc.Do("SENTINEL", "get-master-addr-by-name", name))
-  masterAddr := strings.Join(res, ":")
-  return masterAddr, err
+	res, err := Strings(sc.Do("SENTINEL", "get-master-addr-by-name", name))
+	masterAddr := strings.Join(res, ":")
+	return masterAddr, err
 }
 
-// QueryConfForSlaves looks up the configuration for a named monitored 
+// QueryConfForSlaves looks up the configuration for a named monitored
 // instance set and returns all the slave configuration. Note that the return is
 // a []map[string]string, and will most likely need to be interpreted by
 // SlaveAddr to be usable.
 func (sc *SentinelClient) QueryConfForSlaves(name string) ([]map[string]string, error) {
-  res, err := Values(sc.Do("SENTINEL", "slaves", name))
-  if err != nil {
-    return nil, err
-  }
-  slaves := make([]map[string]string, 0)
-  for _,a := range(res) {
-    sm, err := StringMap(a, err)
-    if err != nil {
-      return slaves, err
-    }
-    slaves = append(slaves, sm)
-  }
-  return slaves, err
+	res, err := Values(sc.Do("SENTINEL", "slaves", name))
+	if err != nil {
+		return nil, err
+	}
+	slaves := make([]map[string]string, 0)
+	for _, a := range res {
+		sm, err := StringMap(a, err)
+		if err != nil {
+			return slaves, err
+		}
+		slaves = append(slaves, sm)
+	}
+	return slaves, err
 }
 
-// A convenience function which formats only the relevant parts of a single 
+// A convenience function which formats only the relevant parts of a single
 // slave map[string]string into an address ip:port pair.
 func SlaveAddr(slaveMap map[string]string) string {
-  return fmt.Sprintf("%s:%s", slaveMap["ip"], slaveMap["port"])
+	return fmt.Sprintf("%s:%s", slaveMap["ip"], slaveMap["port"])
 }
 
 // A convenience function that turns the comma-separated list of string flags
 // from a slave's map[string]string into a map[string]bool for easy testing.
 func SlaveReadFlags(slaveMap map[string]string) map[string]bool {
-  keys := strings.Split(slaveMap["flags"], ",")
-  res := make(map[string]bool)
-  for _,k := range(keys) {
-    res[k] = true
-  }
-  return res
+	keys := strings.Split(slaveMap["flags"], ",")
+	res := make(map[string]bool)
+	for _, k := range keys {
+		res[k] = true
+	}
+	return res
 }
 
-// DialMaster returns a connection to the master of the named monitored 
-// instance set. 
-// 
-// Assumes the same network will be used to contact the master as the one used 
+// DialMaster returns a connection to the master of the named monitored
+// instance set.
+//
+// Assumes the same network will be used to contact the master as the one used
 // for contacting the sentinels.
 //
 // DialMaster returns immediately on failure.
 func (sc *SentinelClient) DialMaster(name string) (Conn, error) {
-  masterAddr, err := sc.QueryConfForMaster(name)
+	masterAddr, err := sc.QueryConfForMaster(name)
 
-  if err != nil {
-    return nil, err
-  }
+	if err != nil {
+		return nil, err
+	}
 
-  return Dial(sc.net, masterAddr)
+	return Dial(sc.net, masterAddr)
 }
 
 var NoSlavesRemaining error = errors.New("No connected slaves with active master-link available")
 
-// DialSlave returns a connection to a slave. This routine mandates that the 
-// slave have an active link to the master, and not be currently flagged as 
+// DialSlave returns a connection to a slave. This routine mandates that the
+// slave have an active link to the master, and not be currently flagged as
 // disconnected. Then a slave is randomly selected from the list.
 //
-// On failure, this method tries again through all slaves that meet the 
-// aforementioned criteria until success or all available options are 
+// On failure, this method tries again through all slaves that meet the
+// aforementioned criteria until success or all available options are
 // exhausted, at which point NoSlavesRemaining is returned.
 //
 // To change this behavior, implement a dialer using QueryConfForSlaves.
 func (sc *SentinelClient) DialSlave(name string) (Conn, error) {
-  slaves, err := sc.QueryConfForSlaves(name)
-  if err != nil {
-    return nil, err
-  }
-  for len(slaves) > 0 {
-    index := rand.Int31n(int32(len(slaves)))
-    flags := SlaveReadFlags(slaves[index])
-    if slaves[index]["master-link-status"] == "ok" && !(flags["disconnected"] || flags["sdown"]){
-      conn, err := Dial(sc.net, SlaveAddr(slaves[index]))
-      if err == nil {
-        return conn, err
-      }
-    }
-    slaves = append(slaves[:index], slaves[index+1:]...)
-  }
-  return nil, NoSlavesRemaining
+	slaves, err := sc.QueryConfForSlaves(name)
+	if err != nil {
+		return nil, err
+	}
+	for len(slaves) > 0 {
+		index := rand.Int31n(int32(len(slaves)))
+		flags := SlaveReadFlags(slaves[index])
+		if slaves[index]["master-link-status"] == "ok" && !(flags["disconnected"] || flags["sdown"]) {
+			conn, err := Dial(sc.net, SlaveAddr(slaves[index]))
+			if err == nil {
+				return conn, err
+			}
+		}
+		slaves = append(slaves[:index], slaves[index+1:]...)
+	}
+	return nil, NoSlavesRemaining
 }
 
 // Exposes the Close of the underlying Conn
 func (sc *SentinelClient) Close() error {
-  return sc.Conn.Close()
+	return sc.Conn.Close()
 }
 
 // Exposes the Err of the underlying Conn
 func (sc *SentinelClient) Err() error {
-  return sc.Conn.Err()
+	return sc.Conn.Err()
 }
 
 // Recursive Send, like Do, performs a Send() on the underlying Conn, trying
 // all configured sentinels if the current connection fails.
 func (sc *SentinelClient) Send(commandName string, args ...interface{}) error {
-  return sc.send(sc.SentinelAddrs, commandName, args...)
+	return sc.send(sc.SentinelAddrs, commandName, args...)
 }
 
 func (sc *SentinelClient) send(addrs []string, commandName string, args ...interface{}) error {
-  err := sc.Conn.Send(commandName, args...)
-  if err != nil {
-    sc.Conn.Close()
-    err, leftovers := sc.dial(addrs)
-    if err != nil {
-      return err
-    } else {
-      return sc.send(leftovers, commandName, args...)
-    }
-  }
-  return nil
+	err := sc.Conn.Send(commandName, args...)
+	if err != nil {
+		sc.Conn.Close()
+		err, leftovers := sc.dial(addrs)
+		if err != nil {
+			return err
+		} else {
+			return sc.send(leftovers, commandName, args...)
+		}
+	}
+	return nil
 }
 
 // Flushes the underlying connection.
@@ -266,7 +265,7 @@ func (sc *SentinelClient) send(addrs []string, commandName string, args ...inter
 // subsequent calls to Send or Do, or through intermediate calls to Dial,
 // if fallback behavior is required due to a broken connection.
 func (sc *SentinelClient) Flush() error {
-  return sc.Conn.Flush()
+	return sc.Conn.Flush()
 }
 
 // Receives a single reply from the underlying redis connection.
@@ -279,58 +278,57 @@ func (sc *SentinelClient) Flush() error {
 // Do will guarantee that the sending and receiving steps occur on the
 // same connection.
 func (sc *SentinelClient) Receive() (reply interface{}, err error) {
-  return sc.Conn.Receive()
+	return sc.Conn.Receive()
 }
 
-// GetRole is a convenience function supplied to query an instance (master or 
-// slave) for its role. It attempts to use the ROLE command introduced in 
+// GetRole is a convenience function supplied to query an instance (master or
+// slave) for its role. It attempts to use the ROLE command introduced in
 // redis 2.8.12. Failing this, the INFO replication command is used instead.
 //
-// If it is known that the cluster is older than 2.8.12, GetReplicationRole 
+// If it is known that the cluster is older than 2.8.12, GetReplicationRole
 // should be used instead, as this bypasses an extraneous ROLE command.
 //
 // It is recommended by the redis client guidelines to test the role of any
-// newly established connection before use. Additionally, if sentinels in use 
-// are older than 2.8.12, they will not force clients to reconnect on role 
-// change; use of long-lived connections in an environment like this (for 
-// example, when using the pool) should involve periodic role testing to 
+// newly established connection before use. Additionally, if sentinels in use
+// are older than 2.8.12, they will not force clients to reconnect on role
+// change; use of long-lived connections in an environment like this (for
+// example, when using the pool) should involve periodic role testing to
 // protect against unexpected changes. See the SentinelAwarePool example for
 // details.
 func GetRole(c Conn) (string, error) {
-  res, err := c.Do("ROLE")
+	res, err := c.Do("ROLE")
 
-  rres, ok := res.([]interface{})
-  if err == nil && ok {
-    return String(rres[0], nil)
-  }
-  return GetReplicationRole(c)
+	rres, ok := res.([]interface{})
+	if err == nil && ok {
+		return String(rres[0], nil)
+	}
+	return GetReplicationRole(c)
 }
 
 // Queries the role of a connected redis instance by checking the output of the
 // INFO replication section. GetRole should be used if the redis instance
 // is sufficiently new to support it.
 func GetReplicationRole(c Conn) (string, error) {
-  res, err := String(c.Do("INFO", "replication"))
-  if err == nil {
-    sres := strings.Split(res, "\r\n")
-    for _,s := range(sres) {
-      si := strings.Split(s,":")
-      if si[0] == "role" {
-        return si[1], nil
-      }
-    }
-  }
-  return "", err
+	res, err := String(c.Do("INFO", "replication"))
+	if err == nil {
+		sres := strings.Split(res, "\r\n")
+		for _, s := range sres {
+			si := strings.Split(s, ":")
+			if si[0] == "role" {
+				return si[1], nil
+			}
+		}
+	}
+	return "", err
 }
 
-// TestRole wraps GetRole in a test to verify if the role matches an expected 
-// role string. If there was any error in querying the supplied connection, 
+// TestRole wraps GetRole in a test to verify if the role matches an expected
+// role string. If there was any error in querying the supplied connection,
 // the function returns false.
 func TestRole(c Conn, expectedRole string) bool {
-  role, err := GetRole(c)
-  if err != nil || role != expectedRole {
-    return false
-  }
-  return true
+	role, err := GetRole(c)
+	if err != nil || role != expectedRole {
+		return false
+	}
+	return true
 }
-

--- a/redis/sentinel.go
+++ b/redis/sentinel.go
@@ -1,0 +1,136 @@
+package redis
+
+import (
+  "errors"
+  "fmt"
+  "math/rand"
+  "time"
+)
+
+type SentinelClient struct {
+  SentinelAddrs []string
+  net string
+  Conn Conn
+  ElectSentinel func([]string) (int)
+  connectTimeout time.Duration
+  readTimeout time.Duration
+  writeTimeout time.Duration
+  remainingAddrs []string
+}
+
+// Returns a SentinelClient with an active connection to at least 
+// one currently active master.
+// ElectSentinel expects a function that dictates the behavior for dialing
+// (see ElectSentinel, below). If nil, the sentinel will use a simple
+// fallback scheme, trying each address until one works.
+// As per the redis-sentinel client guidelines, a timeout is mandatory
+// while connecting to sentinels.
+// Note that in a worst-case scenario, the timeout for performing an
+// operation with a SentinelClient wrapper method may take (# sentinels) *
+// timeout to test and connect to the various configured addresses.
+func NewSentinelClient(net string, addrs []string, electSentinel func([]string) int,
+  connectTimeout, readTimeout, writeTimeout time.Duration) (*SentinelClient, error) {
+  if electSentinel == nil {
+    electSentinel = fallbackElectSentinel
+  }
+  sc := &SentinelClient{
+    net : net,
+    SentinelAddrs : addrs,
+    ElectSentinel : electSentinel,
+    connectTimeout : connectTimeout,
+    readTimeout : readTimeout,
+    writeTimeout : writeTimeout,
+    remainingAddrs : make([]string, 0),
+  }
+
+  err := sc.Dial()
+
+  return sc, err
+}
+
+// The default ElectSentinel implementation, just elects the first sentinel
+// in the list every time.
+func fallbackElectSentinel(addrs []string) int {
+  return 0
+}
+
+// For convenience, supply a purely random sentinel elector
+func RandomElectSentinel(addrs []string) int {
+  return int(rand.Int31n(int32(len(addrs))))
+}
+
+
+// NoSentinelsLeft is returned when all sentinels in the list are exhausted 
+// (or none configured), and contains the last error returned by Dial (which
+// may be nil)
+type NoSentinelsLeft struct {
+  lastError error
+}
+
+func (ns NoSentinelsLeft) Error() string {
+  return fmt.Sprintf("redigo: no configured sentinels successfully connected; last error: %s", ns.lastError.Error())
+}
+
+// Dial connects to the sentinel, NOT the members of a monitored instance group.
+// You can lookup the configuration of any named instance group after dial or use
+// one of the convenience methods to obtain a connection to the redis instances.
+func (sc *SentinelClient) Dial() error {
+  if sc.SentinelAddrs == nil {
+    return errors.New("No configured sentinel addresses")
+  }
+
+  err, leftovers := sc.dial(sc.SentinelAddrs)
+  sc.remainingAddrs = leftovers
+  return err
+}
+
+func (sc *SentinelClient) dial(addrs []string) (error, []string) {
+  var lastErr error
+
+  for subSentList := addrs; len(subSentList) > 0; {
+    i := sc.ElectSentinel(subSentList)
+    addr := subSentList[i]
+    subSentList = append(subSentList[:i], subSentList[i+1:]...)
+    conn, err := DialTimeout(sc.net, addr, sc.connectTimeout, sc.readTimeout, sc.writeTimeout)
+    if err == nil {
+      sc.Conn = conn
+      return nil, subSentList
+    }
+  }
+
+  return NoSentinelsLeft{lastError : lastErr}, []string{}
+}
+
+// Do is the entry point to the recursive do(), and performs the requested 
+// command on the currently connected sentinel, trying all other configured
+// sentinels until the list is exhausted. 
+func (sc *SentinelClient) Do(cmd string, args ...interface{}) (interface{}, error) {
+  return sc.do(sc.SentinelAddrs, cmd, args...)
+}
+
+// A wrapped version of the underlying conn.Do that attempts to restablish
+// the sentinel connection on failure, and tries until all sentinels have
+// been tried.
+func (sc *SentinelClient) do(addrs []string, cmd string, args ...interface{}) (interface{}, error) {
+  var leftovers []string
+  if err := sc.Conn.Err(); err != nil {
+    err, leftovers = sc.dial(addrs)
+    if err != nil {
+      return nil, err
+    }
+  }
+  res, err := sc.Conn.Do(cmd, args...)
+  if err != nil && res == nil { // indicates connection error of some sort
+    sc.Conn.Close()
+    return sc.do(leftovers, cmd, args...)
+  } else {
+    return res, err
+  }
+}
+
+// QueryConfForMaster looks up the configuration for a named monitored instance set
+// and returns the master's configuration.
+func (sc *SentinelClient) QueryConfForMaster(name string) (string, error) {
+  res, err := String(sc.Do("SENTINEL", "get-master-addr-by-name", name))
+  return res, err
+}


### PR DESCRIPTION
Briefly, the SentinelClient supplied by sentinel.go represents a connection to a bundle of sentinels. While only one connection is active at a time, the SentinelClient will failover its internal connection to all configured sentinels before failing any individual operation.

The SentinelClient has a Dial method, which connects to the sentinel, and DialMaster and DialSlave methods, which connect to the named master or slaves of the named master, respectively.

The SentinelAwarePool supplied in pool.go is extremely simple. I wanted to avoid an overly-complex implementation here, because I don't have a lot of operational experience with the Pool. The only differences are the addition of a TestOnReturn entry point, which is designed to test returned connections for role changes, and a method to update the internal accounting of the master's address. (Role detection and test wrappers are supplied in sentinel.go). The only meaningful operational difference to the SentinelAwarePool is the ability to purge all idle connections if the master's configuration changes. (active connections will be handled by TestOnReturn).

An example of usage of the SentinelAwarePool is supplied in pool.go.

I believe I have supplied sufficient capability here for a barebones but fully capable sentinel configuration, and enough tools and flexibility for a user to build a more complex setup (including using Sentinel pubsub, which is not included here.)

I've tested this (both pool and standalone connections) on a new 2.8 cluster and an older 2.6-era cluster which does not have CLIENT kill. I would appreciate additional testing and validation if possible, especially on the new 3.0 cluster which I do not have access to.
