### PR TITLE
Improve performance of LookupCommandInfo.

### DIFF
--- a/internal/commandinfo.go
+++ b/internal/commandinfo.go
@@ -29,17 +29,49 @@ type CommandInfo struct {
 	Set, Clear int
 }
 
+var (
+	watch      = CommandInfo{Set: WatchState}
+	unwatch    = CommandInfo{Clear: WatchState}
+	multi      = CommandInfo{Set: MultiState}
+	exec       = CommandInfo{Clear: WatchState | MultiState}
+	discard    = CommandInfo{Clear: WatchState | MultiState}
+	psubscribe = CommandInfo{Set: SubscribeState}
+	subscribe  = CommandInfo{Set: SubscribeState}
+	monitor    = CommandInfo{Set: MonitorState}
+)
+
 var commandInfos = map[string]CommandInfo{
-	"WATCH":      {Set: WatchState},
-	"UNWATCH":    {Clear: WatchState},
-	"MULTI":      {Set: MultiState},
-	"EXEC":       {Clear: WatchState | MultiState},
-	"DISCARD":    {Clear: WatchState | MultiState},
-	"PSUBSCRIBE": {Set: SubscribeState},
-	"SUBSCRIBE":  {Set: SubscribeState},
-	"MONITOR":    {Set: MonitorState},
+	"WATCH":      watch,
+	"UNWATCH":    unwatch,
+	"MULTI":      multi,
+	"EXEC":       exec,
+	"DISCARD":    discard,
+	"PSUBSCRIBE": psubscribe,
+	"SUBSCRIBE":  subscribe,
+	"MONITOR":    monitor,
 }
 
 func LookupCommandInfo(commandName string) CommandInfo {
-	return commandInfos[strings.ToUpper(commandName)]
+
+	// optimize for correctly cased strings
+	switch commandName {
+	case "MULTI", "multi":
+		return multi
+	case "EXEC", "exec":
+		return exec
+	case "WATCH", "watch":
+		return watch
+	case "UNWATCH", "unwatch":
+		return unwatch
+	case "PSUBSCRIBE", "psubcribe":
+		return psubscribe
+	case "SUBSCRIBE", "subscribe":
+		return subscribe
+	case "MONITOR", "monitor":
+		return monitor
+	default:
+		// if it's mixed case or unknown, fallback to our map which is
+		// slower.
+		return commandInfos[strings.ToUpper(commandName)]
+	}
 }

--- a/internal/commandinfo_test.go
+++ b/internal/commandinfo_test.go
@@ -1,0 +1,42 @@
+package internal
+
+import "testing"
+
+func TestLookupCommandInfo(t *testing.T) {
+
+	for _, c := range []string{"watch", "WATCH", "wAtch"} {
+		w := LookupCommandInfo(c)
+		if w.Set != WatchState {
+			t.Errorf("watch state not equal!")
+		}
+		if w.Clear != 0 {
+			t.Errorf("watch state not equal!")
+		}
+
+	}
+
+}
+
+func BenchmarkLookupCommandInfoCorrectCase(b *testing.B) {
+
+	cases := []string{
+		"watch", "WATCH", "monitor", "MONITOR"}
+	// run the Fib function b.N times
+	for n := 0; n < b.N; n++ {
+		for _, c := range cases {
+			LookupCommandInfo(c)
+		}
+	}
+}
+
+func BenchmarkLookupCommandInfoMixedCase(b *testing.B) {
+
+	cases := []string{
+		"wAtch", "mOnitor"}
+	// run the Fib function b.N times
+	for n := 0; n < b.N; n++ {
+		for _, c := range cases {
+			LookupCommandInfo(c)
+		}
+	}
+}


### PR DESCRIPTION
Converting command names to upper case is a non-trival part of our
profile. Assuming that 99% of programmers don't use mixed case,
we can optimize that by explicitly checking the lower/upper case
commands and short-circuiting before upper casing.

This makes mixed cases marginally slower, but makes the common case much
faster. A good trade-off I think.

```
BEFORE:

BenchmarkLookupCommandInfoCorrectCase    2000000           716 ns/op
BenchmarkLookupCommandInfoMixedCase      3000000           532 ns/op

AFTER:

BenchmarkLookupCommandInfoCorrectCase   10000000           131 ns/op
BenchmarkLookupCommandInfoMixedCase     2000000           593 ns/op
```