### PR TITLE
In this case, the reply is []strings{string,string...}, the func Strings does not handle this case. Fix it.

### DIFF
--- a/redis/reply.go
+++ b/redis/reply.go
@@ -256,11 +256,14 @@ func Strings(reply interface{}, err error) ([]string, error) {
 			if reply[i] == nil {
 				continue
 			}
-			p, ok := reply[i].([]byte)
-			if !ok {
+			switch reply[i].(type) {
+			case []byte:
+				result[i] = string(p)
+			case string:
+				result[i] = string(p)
+			default:
 				return nil, fmt.Errorf("redigo: unexpected element type for Strings, got type %T", reply[i])
 			}
-			result[i] = string(p)
 		}
 		return result, nil
 	case nil:

--- a/redis/reply_test.go
+++ b/redis/reply_test.go
@@ -53,6 +53,11 @@ var replyTests = []struct {
 		ve([]string{"v1", "v2"}, nil),
 	},
 	{
+		"strings([v1, v2])",
+		ve(redis.Strings([]interface{}{"v1", "v2"}, nil)),
+		ve([]string{"v1", "v2"}, nil),
+	},
+	{
 		"strings(nil)",
 		ve(redis.Strings(nil, nil)),
 		ve([]string(nil), redis.ErrNil),


### PR DESCRIPTION
In this case, the reply is []strings{string,string...}, the func Strings does not handle this case.
```
// test_redigo project main.go
package main

import (
	"fmt"
	redis "github.com/garyburd/redigo/redis"
)

const (
	MULTI = "MULTI"
	TYPE  = "TYPE"
	HSET  = "HSET"
	SADD  = "SADD"
	SET   = "SET"
	LPUSH = "LPUSH"
	EXEC  = "EXEC"
)

func main() {

	r, _ := redis.Dial("tcp", "127.0.0.1:6379")

	r.Send(MULTI)
	r.Send(SADD, "SETKEY", "one")
	r.Send(LPUSH, "LISTKEY", "list")
	r.Send(HSET, "HASHKEY", "key", "value")
	r.Send(SET, "STRINGKEY", "string")
	r.Do(EXEC)

	r.Send(MULTI)
	r.Send(TYPE, "SETKEY")
	r.Send(TYPE, "LISTKEY")
	r.Send(TYPE, "HASHKEY")
	r.Send(TYPE, "STRINGKEY")

	fmt.Println(redis.Strings(r.Do(EXEC)))
```
