### PR TITLE
Export Dialer interface for Redis URLs

### DIFF
--- a/redis/conn_test.go
+++ b/redis/conn_test.go
@@ -17,6 +17,7 @@ package redis_test
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"math"
 	"net"
 	"reflect"
@@ -422,6 +423,101 @@ func TestReadDeadline(t *testing.T) {
 	}
 }
 
+var dialErrors = []struct {
+	rawurl        string
+	expectedError string
+}{
+	{
+		":",
+		"parse",
+	},
+	{
+		"localhost",
+		"invalid redis URL scheme",
+	},
+	{
+		"redis://weird url",
+		"no such host",
+	},
+	{
+		"redis://foo:bar:baz",
+		"invalid address host",
+	},
+	{
+		"http://www.google.com",
+		"invalid redis URL scheme: http",
+	},
+	{
+		"redis://x:abc123@localhost",
+		"invalid password: abc123",
+	},
+	{
+		"redis://localhost:6379/abc123",
+		"invalid database: abc123",
+	},
+}
+
+func TestDialer(t *testing.T) {
+	for _, d := range dialErrors {
+		_, err := redis.NewDialer(d.rawurl).Dial()
+		if err == nil || !strings.Contains(err.Error(), d.expectedError) {
+			t.Errorf("NewDialer did not throw correct error (expected %v to contain %s)", err, d.expectedError)
+		}
+	}
+
+	checkPort := func(network, address string) (net.Conn, error) {
+		if address != "localhost:6379" {
+			t.Errorf("NewDialer did not set port to 6379 by default (got %v)", address)
+		}
+		return net.Dial(network, address)
+	}
+	d := redis.NewDialerNetDial("redis://localhost", checkPort)
+	c, err := d.Dial()
+	if err != nil {
+		t.Error("dial error:", err)
+	}
+	c.Close()
+
+	checkHost := func(network, address string) (net.Conn, error) {
+		if address != "localhost:6379" {
+			t.Errorf("NewDialer did not set host to localhost by default (got %v)", address)
+		}
+		return net.Dial(network, address)
+	}
+	d = redis.NewDialerNetDial("redis://:6379", checkHost)
+	c, err = d.Dial()
+	if err != nil {
+		t.Error("dial error:", err)
+	}
+	c.Close()
+
+	// Check that the database is set correctly
+	c1, err := redis.NewDialer("redis://:6379/8").Dial()
+	defer c1.Close()
+	if err != nil {
+		t.Error("Dial error:", err)
+	}
+	c1.Do("SET", "var", "val")
+
+	c2, err := redis.Dial("tcp", ":6379")
+	defer c2.Close()
+	if err != nil {
+		t.Error("dial error:", err)
+	}
+	_, err = c2.Do("SELECT", "8")
+	if err != nil {
+		t.Error(err)
+	}
+	got, err := redis.String(c2.Do("GET", "var"))
+	if err != nil {
+		t.Error(err)
+	}
+	if got != "val" {
+		t.Error("NewDialer did not correctly set the db.")
+	}
+	_, err = c2.Do("DEL", "var")
+}
+
 // Connect to local instance of Redis running on the default port.
 func ExampleDial(x int) {
 	c, err := redis.Dial("tcp", ":6379")
@@ -429,6 +525,18 @@ func ExampleDial(x int) {
 		// handle error
 	}
 	defer c.Close()
+}
+
+// Connect to a remote instance of Redis using a redis:// scheme.
+func ExampleDialer() {
+	d := redis.NewDialer("redis://x:abc123@1.2.3.4:6379/3")
+	c, err := d.Dial()
+	if err != nil {
+		// connection failed, handle error
+		fmt.Println("Dial error:", err)
+	}
+	defer c.Close()
+
 }
 
 // TextExecError tests handling of errors in a transaction. See

--- a/redis/pool_test.go
+++ b/redis/pool_test.go
@@ -59,7 +59,7 @@ type poolDialer struct {
 	dialErr  error
 }
 
-func (d *poolDialer) dial() (redis.Conn, error) {
+func (d *poolDialer) Dial() (redis.Conn, error) {
 	d.dialed += 1
 	if d.dialErr != nil {
 		return nil, d.dialErr
@@ -88,7 +88,7 @@ func TestPoolReuse(t *testing.T) {
 	d := poolDialer{t: t}
 	p := &redis.Pool{
 		MaxIdle: 2,
-		Dial:    d.dial,
+		Dialer:  &d,
 	}
 
 	for i := 0; i < 10; i++ {
@@ -109,7 +109,7 @@ func TestPoolMaxIdle(t *testing.T) {
 	d := poolDialer{t: t}
 	p := &redis.Pool{
 		MaxIdle: 2,
-		Dial:    d.dial,
+		Dialer:  &d,
 	}
 	for i := 0; i < 10; i++ {
 		c1 := p.Get()
@@ -131,7 +131,7 @@ func TestPoolError(t *testing.T) {
 	d := poolDialer{t: t}
 	p := &redis.Pool{
 		MaxIdle: 2,
-		Dial:    d.dial,
+		Dialer:  &d,
 	}
 
 	c := p.Get()
@@ -152,7 +152,7 @@ func TestPoolClose(t *testing.T) {
 	d := poolDialer{t: t}
 	p := &redis.Pool{
 		MaxIdle: 2,
-		Dial:    d.dial,
+		Dialer:  &d,
 	}
 
 	c1 := p.Get()
@@ -193,7 +193,7 @@ func TestPoolTimeout(t *testing.T) {
 	p := &redis.Pool{
 		MaxIdle:     2,
 		IdleTimeout: 300 * time.Second,
-		Dial:        d.dial,
+		Dialer:      &d,
 	}
 
 	now := time.Now()
@@ -245,7 +245,7 @@ func TestPoolBorrowCheck(t *testing.T) {
 	d := poolDialer{t: t}
 	p := &redis.Pool{
 		MaxIdle:      2,
-		Dial:         d.dial,
+		Dialer:       &d,
 		TestOnBorrow: func(redis.Conn, time.Time) error { return redis.Error("BLAH") },
 	}
 
@@ -263,7 +263,7 @@ func TestPoolMaxActive(t *testing.T) {
 	p := &redis.Pool{
 		MaxIdle:   2,
 		MaxActive: 2,
-		Dial:      d.dial,
+		Dialer:    &d,
 	}
 	c1 := p.Get()
 	c1.Do("PING")
@@ -297,7 +297,7 @@ func TestPoolMonitorCleanup(t *testing.T) {
 	p := &redis.Pool{
 		MaxIdle:   2,
 		MaxActive: 2,
-		Dial:      d.dial,
+		Dialer:    &d,
 	}
 	c := p.Get()
 	c.Send("MONITOR")
@@ -312,7 +312,7 @@ func TestPoolPubSubCleanup(t *testing.T) {
 	p := &redis.Pool{
 		MaxIdle:   2,
 		MaxActive: 2,
-		Dial:      d.dial,
+		Dialer:    &d,
 	}
 
 	c := p.Get()
@@ -343,7 +343,7 @@ func TestPoolTransactionCleanup(t *testing.T) {
 	p := &redis.Pool{
 		MaxIdle:   2,
 		MaxActive: 2,
-		Dial:      d.dial,
+		Dialer:    &d,
 	}
 
 	c := p.Get()
@@ -432,7 +432,7 @@ func TestWaitPool(t *testing.T) {
 	p := &redis.Pool{
 		MaxIdle:   1,
 		MaxActive: 1,
-		Dial:      d.dial,
+		Dialer:    &d,
 		Wait:      true,
 	}
 	defer p.Close()
@@ -459,7 +459,7 @@ func TestWaitPoolClose(t *testing.T) {
 	p := &redis.Pool{
 		MaxIdle:   1,
 		MaxActive: 1,
-		Dial:      d.dial,
+		Dialer:    &d,
 		Wait:      true,
 	}
 	c := p.Get()
@@ -493,7 +493,7 @@ func TestWaitPoolCommandError(t *testing.T) {
 	p := &redis.Pool{
 		MaxIdle:   1,
 		MaxActive: 1,
-		Dial:      d.dial,
+		Dialer:    &d,
 		Wait:      true,
 	}
 	defer p.Close()
@@ -521,7 +521,7 @@ func TestWaitPoolDialError(t *testing.T) {
 	p := &redis.Pool{
 		MaxIdle:   1,
 		MaxActive: 1,
-		Dial:      d.dial,
+		Dialer:    &d,
 		Wait:      true,
 	}
 	defer p.Close()
@@ -572,7 +572,7 @@ func TestLocking_TestOnBorrowFails_PoolDoesntCrash(t *testing.T) {
 	p := &redis.Pool{
 		MaxIdle:   count,
 		MaxActive: count,
-		Dial:      d.dial,
+		Dialer:    &d,
 		TestOnBorrow: func(c redis.Conn, t time.Time) error {
 			return errors.New("No way back into the real world.")
 		},


### PR DESCRIPTION
Let me know if this interface is what you had in mind. Ideally, the
NewDialer function should probably also accept some other URL schemes as
well (let me know your thoughts--I think the Ruby client also accepts
unix and TCP sockets).