### PR TITLE
Add DialURL to allow connection using a Redis URL

### DIFF
--- a/redis/conn.go
+++ b/redis/conn.go
@@ -97,6 +97,15 @@ func DialConnectTimeout(d time.Duration) DialOption {
 	}}
 }
 
+// DialNetDial specifies a custom dial function for creating TCP
+// connections. If this option is left out, then net.Dial is
+// used. DialNetDial overrides DialConnectTimeout.
+func DialNetDial(dial func(network, addr string) (net.Conn, error)) DialOption {
+	return DialOption{func(do *dialOptions) {
+		do.dial = dial
+	}}
+}
+
 // DialDatabase specifies the database to select when dialing a connection.
 func DialDatabase(db int) DialOption {
 	return DialOption{func(do *dialOptions) {


### PR DESCRIPTION
After thinking about it some more, I think it's cleaner to take a URL
object instead of an unparsed string, but I think either way would work.