### PR TITLE
Fix bux causing Ints call to swallow error returned from the connecton object

### DIFF
--- a/redis/reply.go
+++ b/redis/reply.go
@@ -275,9 +275,6 @@ func Strings(reply interface{}, err error) ([]string, error) {
 // err is not equal to nil, then Ints returns nil, err.
 func Ints(reply interface{}, err error) ([]int, error) {
 	var ints []int
-	if reply == nil {
-		return ints, ErrNil
-	}
 	values, err := Values(reply, err)
 	if err != nil {
 		return ints, err


### PR DESCRIPTION
Like in the description. 

Discovered it when i stopped redis server, but my app was returning errNil and not connection errors 