### PR TITLE
allow for multi-digit redis db numbers (eg: "10")

### DIFF
--- a/redis/conn.go
+++ b/redis/conn.go
@@ -162,7 +162,7 @@ func Dial(network, address string, options ...DialOption) (Conn, error) {
 	return c, nil
 }
 
-var pathDBRegexp = regexp.MustCompile(`/(\d)\z`)
+var pathDBRegexp = regexp.MustCompile(`/(\d+)\z`)
 
 // DialURL connects to a Redis server at the given URL using the Redis
 // URI scheme. URLs should follow the draft IANA specification for the


### PR DESCRIPTION
The redis URL support added on 08/30 has a regex which only allows single digit database numbers.  This change allows for multi-digit database numbers.