### PR TITLE
[reply] Add ByteSlices conversion helper

### DIFF
--- a/redis/reply.go
+++ b/redis/reply.go
@@ -273,6 +273,36 @@ func Strings(reply interface{}, err error) ([]string, error) {
 	return nil, fmt.Errorf("redigo: unexpected type for Strings, got type %T", reply)
 }
 
+// ByteSlices is a helper that converts an array command reply to a [][]byte.
+// If err is not equal to nil, then ByteSlices returns nil, err. Nil array
+// items are stay nil. ByteSlices returns an error if an array item is not a
+// bulk string or nil.
+func ByteSlices(reply interface{}, err error) ([][]byte, error) {
+	if err != nil {
+		return nil, err
+	}
+	switch reply := reply.(type) {
+	case []interface{}:
+		result := make([][]byte, len(reply))
+		for i := range reply {
+			if reply[i] == nil {
+				continue
+			}
+			p, ok := reply[i].([]byte)
+			if !ok {
+				return nil, fmt.Errorf("redigo: unexpected element type for ByteSlices, got type %T", reply[i])
+			}
+			result[i] = p
+		}
+		return result, nil
+	case nil:
+		return nil, ErrNil
+	case Error:
+		return nil, reply
+	}
+	return nil, fmt.Errorf("redigo: unexpected type for ByteSlices, got type %T", reply)
+}
+
 // Ints is a helper that converts an array command reply to a []int. If
 // err is not equal to nil, then Ints returns nil, err.
 func Ints(reply interface{}, err error) ([]int, error) {

--- a/redis/reply_test.go
+++ b/redis/reply_test.go
@@ -57,6 +57,16 @@ var replyTests = []struct {
 		ve([]string(nil), redis.ErrNil),
 	},
 	{
+		"byteslices([v1, v2])",
+		ve(redis.ByteSlices([]interface{}{[]byte("v1"), []byte("v2")}, nil)),
+		ve([][]byte{[]byte("v1"), []byte("v2")}, nil),
+	},
+	{
+		"byteslices(nil)",
+		ve(redis.ByteSlices(nil, nil)),
+		ve([][]byte(nil), redis.ErrNil),
+	},
+	{
 		"values([v1, v2])",
 		ve(redis.Values([]interface{}{[]byte("v1"), []byte("v2")}, nil)),
 		ve([]interface{}{[]byte("v1"), []byte("v2")}, nil),


### PR DESCRIPTION
This PR adds a `ByteSlices` helper, which is basically the same as `Strings`, except that it's for `[][]byte` instead of for `[]string`. It's nice to have since it doesn't have to do any allocations to convert each element in the array reply from a `[]byte` to a `string`.