### PR TITLE
Add a DialOption for passing a tls.Config, use tls dialer if config is

### DIFF
--- a/redis/conn_test.go
+++ b/redis/conn_test.go
@@ -16,6 +16,7 @@ package redis_test
 
 import (
 	"bytes"
+	"crypto/tls"
 	"io"
 	"math"
 	"net"
@@ -536,6 +537,20 @@ func TestDialURLDatabase(t *testing.T) {
 	actual0 := buf0.String()
 	if actual0 != expected0 {
 		t.Errorf("commands = %q, want %q", actual0, expected0)
+	}
+}
+
+func TestDialTLSConfig(t *testing.T) {
+	// Passing nil will return the regular dialer
+	_, err := redis.DialURL("redis://localhost", redis.DialTLSConfig(nil))
+	if err != nil {
+		t.Error("dial error:", err)
+	}
+
+	// Passing a TLS config will attempt to dial with TLS config, and will timeout if not connected within 1 second
+	_, err = redis.DialURL("redis://localhost", redis.DialTLSConfig(&tls.Config{}))
+	if err == nil {
+		t.Error("dial error: expected connection to timeout for tls connection")
 	}
 }
 


### PR DESCRIPTION
This PR adds support for dialing a tcp connection over TLS to redigo. The main use case for this is *TLS offloading* using something like HAProxy and allows for the redigo client to talk to a redis that is securely proxied.

I saw that #99 is still open, but feel like while this PR and that issue are related, they are ultimately orthogonal. This adds support for people using proxy-based solutions like HAProxy, or perhaps other solutions like stunnel. When antirez adds mainline TLS, this feature might be better served by native TLS support in Redis (or Sentinel), but for now it's fairly common to have HAProxy in front of a Sentinel setup.

ps thanks for the great work on redigo!