### PR TITLE
Adding ConnMutex for threadsafe Do()

### DIFF
--- a/redis/conn.go
+++ b/redis/conn.go
@@ -568,3 +568,24 @@ func (c *conn) Do(cmd string, args ...interface{}) (interface{}, error) {
 	}
 	return reply, err
 }
+
+type connMutex struct {
+	Conn
+	Mutex *sync.Mutex
+}
+
+func (c *connMutex) Do(cmd string, args ...interface{}) (interface{}, error) {
+	c.Mutex.Lock()
+	reply, err := c.Conn.Do(cmd, args...)
+	c.Mutex.Unlock()
+	return reply, err
+}
+
+type ConnMutex interface {
+	Do(commandName string, args ...interface{}) (reply interface{}, err error)
+}
+
+func DialMutex(network, address string, options ...DialOption) (ConnMutex, error) {
+	c, err := Dial(network, address, options...)
+	return &connMutex{c, &sync.Mutex{}}, err
+}


### PR DESCRIPTION
`ConnMutex` is a wrapper for `Conn` where its `Do` method is wrapped in a `sync.Mutex`. It only implements the `Do` method. `redis.DialMutex` has the same syntax as `redis.Dial` and returns a `ConnMutex`. The `Do` method has the same syntax as for the `Conn` interface.

```
client := redis.DialMutex("tcp", ":6379")
reply, err := client.Do("INCR", "myvalue", 1)
```

(My application wants a lot of concurrent `Do()` calls, and I got tired of exhausting a pool under heavy load, so I started using a single connection and wrapping everything in a `sync.Mutex`. I thought this may be useful to more than just myself.)