### PR TITLE
trivial spelling fixes

### DIFF
--- a/redis/doc.go
+++ b/redis/doc.go
@@ -99,7 +99,7 @@
 //
 // Concurrency
 //
-// Connections support one concurrent caller to the Recieve method and one
+// Connections support one concurrent caller to the Receive method and one
 // concurrent caller to the Send and Flush methods. No other concurrency is
 // supported including concurrent calls to the Do method.
 //

--- a/redis/pool_test.go
+++ b/redis/pool_test.go
@@ -576,7 +576,7 @@ func TestWaitPoolDialError(t *testing.T) {
 		t.Errorf("expected one nil error, got %d", nilCount)
 	}
 	if errCount != cap(errs)-1 {
-		t.Errorf("expected %d dial erors, got %d", cap(errs)-1, errCount)
+		t.Errorf("expected %d dial errors, got %d", cap(errs)-1, errCount)
 	}
 	d.check("done", p, cap(errs), 0)
 }


### PR DESCRIPTION
(fixing upstream, as used in transfer.sh)