### PR TITLE
Treat named primitive types as primitives, rather than as strings.

### DIFF
--- a/redis/conn_test.go
+++ b/redis/conn_test.go
@@ -46,6 +46,11 @@ func dialTestConn(r io.Reader, w io.Writer) redis.DialOption {
 	})
 }
 
+type connWrappedString string
+type connWrappedInt int
+type connWrappedFloat float64
+type connWrappedBool bool
+
 var writeTests = []struct {
 	args     []interface{}
 	expected string
@@ -55,7 +60,7 @@ var writeTests = []struct {
 		"*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$5\r\nvalue\r\n",
 	},
 	{
-		[]interface{}{"SET", "key", "value"},
+		[]interface{}{"SET", "key", connWrappedString("value")},
 		"*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$5\r\nvalue\r\n",
 	},
 	{
@@ -71,8 +76,28 @@ var writeTests = []struct {
 		"*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$20\r\n-9223372036854775808\r\n",
 	},
 	{
+		[]interface{}{"SET", "key", connWrappedInt(42)},
+		"*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$2\r\n42\r\n",
+	},
+	{
 		[]interface{}{"SET", "key", float64(1349673917.939762)},
 		"*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$21\r\n1.349673917939762e+09\r\n",
+	},
+	{
+		[]interface{}{"SET", "key", connWrappedFloat(123.456)},
+		"*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$7\r\n123.456\r\n",
+	},
+	{
+		[]interface{}{"SET", "key", true},
+		"*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$1\r\n1\r\n",
+	},
+	{
+		[]interface{}{"SET", "key", false},
+		"*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$1\r\n0\r\n",
+	},
+	{
+		[]interface{}{"SET", "key", connWrappedBool(true)},
+		"*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$1\r\n1\r\n",
 	},
 	{
 		[]interface{}{"SET", "key", ""},

--- a/redis/scan_test.go
+++ b/redis/scan_test.go
@@ -23,6 +23,11 @@ import (
 	"github.com/garyburd/redigo/redis"
 )
 
+type scanWrappedString string
+type scanWrappedInt int
+type scanWrappedFloat float64
+type scanWrappedBool bool
+
 var scanConversionTests = []struct {
 	src  interface{}
 	dest interface{}
@@ -32,6 +37,7 @@ var scanConversionTests = []struct {
 	{[]byte("0"), float64(0)},
 	{[]byte("3.14159"), float64(3.14159)},
 	{[]byte("3.14"), float32(3.14)},
+	{[]byte("3.14159"), scanWrappedFloat(3.14159)},
 	{[]byte("-100"), int(-100)},
 	{[]byte("101"), int(101)},
 	{int64(102), int(102)},
@@ -41,15 +47,20 @@ var scanConversionTests = []struct {
 	{int64(106), int8(106)},
 	{[]byte("107"), uint8(107)},
 	{int64(108), uint8(108)},
+	{int64(109), scanWrappedInt(109)},
+	{[]byte("110"), scanWrappedInt(110)},
 	{[]byte("0"), false},
 	{int64(0), false},
 	{[]byte("f"), false},
 	{[]byte("1"), true},
 	{int64(1), true},
 	{[]byte("t"), true},
+	{int64(1), scanWrappedBool(true)},
+	{[]byte("t"), scanWrappedBool(true)},
 	{"hello", "hello"},
 	{[]byte("hello"), "hello"},
 	{[]byte("world"), []byte("world")},
+	{[]byte("hello"), scanWrappedString("hello")},
 	{[]interface{}{[]byte("foo")}, []interface{}{[]byte("foo")}},
 	{[]interface{}{[]byte("foo")}, []string{"foo"}},
 	{[]interface{}{[]byte("hello"), []byte("world")}, []string{"hello", "world"}},
@@ -158,6 +169,10 @@ type s1 struct {
 	Bt bool
 	Bf bool
 	s0
+	Wi scanWrappedInt    `redis:"wi"`
+	Wf scanWrappedFloat  `redis:"wf"`
+	Wb scanWrappedBool   `redis:"wb"`
+	Ws scanWrappedString `redis:"ws"`
 }
 
 var scanStructTests = []struct {
@@ -166,8 +181,8 @@ var scanStructTests = []struct {
 	value interface{}
 }{
 	{"basic",
-		[]string{"i", "-1234", "u", "5678", "s", "hello", "p", "world", "b", "t", "Bt", "1", "Bf", "0", "X", "123", "y", "456"},
-		&s1{I: -1234, U: 5678, S: "hello", P: []byte("world"), B: true, Bt: true, Bf: false, s0: s0{X: 123, Y: 456}},
+		[]string{"i", "-1234", "u", "5678", "s", "hello", "p", "world", "b", "t", "Bt", "1", "Bf", "0", "X", "123", "y", "456", "wi", "91011", "wf", "12.13", "wb", "1", "ws", "wrapped"},
+		&s1{I: -1234, U: 5678, S: "hello", P: []byte("world"), B: true, Bt: true, Bf: false, s0: s0{X: 123, Y: 456}, Wi: 91011, Wf: 12.13, Wb: true, Ws: "wrapped"},
 	},
 }
 


### PR DESCRIPTION
As an interim measure to a more full-featured argument serializer interface, handle simply-wrapped types as their primitives rather than falling back to Stringer-style conversion.

This is particularly useful in the case of enum/iota-style constants that are typed with a specific name.  Previously, any `String()` method on this type would result in those stringified values getting written to redis, and then a parse failure when read, especially when read via `ScanStruct()`, where it's difficult to intervene in the parsing.  With this change, those values are written as their primitive (numeric) type, and thus read as that primitive type, and can be successfully assigned to the named type even when it's a member of a struct.

As an example:

```go
type status int

const (
    StatusUnknown status = iota,
    StatusBad,
    StatusGood,
)

func (s status) String() string {
    switch s {
    case StatusBad:
        return "bad"
    case StatusGood:
        return "good"
    default:
        return "????"
    }
}

struct Data {
    Status status `redis:"status"`
    // ... other fields ...
}

func writeData(conn redis.Conn, hashKey string, data *Data) err {
    _, err := conn.Do("HMSET", redis.Args{}.Add(hashKey).AddFlat(data)...)
    return err
}

func getData(conn redis.Conn, hashKey string) *Data, error {
    data := &Data{}
    err := redis.ScanStruct(redis.Values(conn.Do("HGETALL", hashKey)), data)
    return data, err
}
```

Before this change, redis would have `status: "bad"` (or `status: "good"`) written , and `ScanStruct()` would later fail to parse that as an int.  _With_ this change, redis will get `status: 1` (or `status: 2`) written, and the later `ScanStruct()` will successfully parse the number and assign it to the `Status` member.