### PR TITLE
corrected documentation causing build to fail

### DIFF
--- a/redis/conn.go
+++ b/redis/conn.go
@@ -128,7 +128,8 @@ func DialPassword(password string) DialOption {
 }
 
 // DialTLSConfig specifies the config to use when a TLS connection is dialed.
-// Has no effect when not dialing a TLS connection.func DialTLSConfig(c *tls.Config) DialOption {
+// Has no effect when not dialing a TLS connection.
+func DialTLSConfig(c *tls.Config) DialOption {
 	return DialOption{func(do *dialOptions) {
 		do.tlsConfig = c
 	}}


### PR DESCRIPTION
I'm not sure what you were trying to correct with the original commit - this change reverts a documentation edit that pulled up the function name into the comment itself