### PR TITLE
Fix server start detection for Redis 4

### DIFF
--- a/redis/test_test.go
+++ b/redis/test_test.go
@@ -96,7 +96,8 @@ func (s *Server) watch(r io.Reader, ready chan error) {
 		text = scn.Text()
 		fmt.Fprintf(serverLog, "%s\n", text)
 		if !listening {
-			if strings.Contains(text, "The server is now ready to accept connections on port") {
+			if strings.Contains(text, " * Ready to accept connections") ||
+				strings.Contains(text, " * The server is now ready to accept connections on port") {
 				listening = true
 				ready <- nil
 			}


### PR DESCRIPTION
Redis 4.0.0 was just released and it changes the log message output.
test_test.go fixed to detect server start based on new message.