### PR TITLE
Improve Argument implementation

### DIFF
--- a/redis/conn_test.go
+++ b/redis/conn_test.go
@@ -82,6 +82,10 @@ func (t durationArg) RedisArg() interface{} {
 	return t.Seconds()
 }
 
+type recursiveArg int
+
+func (v recursiveArg) RedisArg() interface{} { return v }
+
 var writeTests = []struct {
 	args     []interface{}
 	expected string
@@ -121,6 +125,10 @@ var writeTests = []struct {
 	{
 		[]interface{}{"SET", "key", durationArg{time.Minute}},
 		"*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$2\r\n60\r\n",
+	},
+	{
+		[]interface{}{"SET", "key", recursiveArg(123)},
+		"*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$3\r\n123\r\n",
 	},
 	{
 		[]interface{}{"ECHO", true, false},

--- a/redis/doc.go
+++ b/redis/doc.go
@@ -48,7 +48,7 @@
 //  float64                 strconv.FormatFloat(v, 'g', -1, 64)
 //  bool                    true -> "1", false -> "0"
 //  nil                     ""
-//  all other types         fmt.Print(v)
+//  all other types         fmt.Fprint(w, v)
 //
 // Redis command reply types are represented using the following Go types:
 //

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -40,18 +40,20 @@ type Conn interface {
 	Receive() (reply interface{}, err error)
 }
 
-// Argument is implemented by types which want to control how their value is
-// interpreted when used as an argument to a redis command.
+// Argument is the interface implemented by an object which wants to control how
+// the object is converted to Redis bulk strings.
 type Argument interface {
-	// RedisArg returns the interface that represents the value to be used
-	// in redis commands.
+	// RedisArg returns a value to be encoded as a bulk string per the
+	// conversions listed in the section 'Executing Commands'.
+	// Implementations should typically return a []byte or string.
 	RedisArg() interface{}
 }
 
-// Scanner is implemented by types which want to control how their value is
-// interpreted when read from redis.
+// Scanner is implemented by an object which wants to control it's value is
+// interpreted when read from Redis.
 type Scanner interface {
-	// RedisScan assigns a value from a redis value.
+	// RedisScan assigns a value from a Redis value. The argument src is one of
+	// the reply types listed in the section `Executing Commands`.
 	//
 	// An error should be returned if the value cannot be stored without
 	// loss of information.


### PR DESCRIPTION
- Encode result of RedisArg() using same conversion as other arguments. This
  change makes []byte return values useful.
- Improve documentation.