### PR TITLE
Method for getting consistent pool statistics added

### DIFF
--- a/redis/pool.go
+++ b/redis/pool.go
@@ -181,6 +181,26 @@ func (p *Pool) Get() Conn {
 	return &pooledConnection{p: p, c: c}
 }
 
+// PoolStats contains pool statistics.
+type PoolStats struct {
+	// ActiveCount is the number of connections in the pool. The count includes idle connections and connections in use.
+	ActiveCount int
+	// IdleCount is the number of idle connections in the pool.
+	IdleCount int
+}
+
+// Stats returns pool's statistics.
+func (p *Pool) Stats() PoolStats {
+	p.mu.Lock()
+	stats := PoolStats{
+		ActiveCount: p.active,
+		IdleCount:   p.idle.Len(),
+	}
+	p.mu.Unlock()
+
+	return stats
+}
+
 // ActiveCount returns the number of connections in the pool. The count includes idle connections and connections in use.
 func (p *Pool) ActiveCount() int {
 	p.mu.Lock()

--- a/redis/pool_test.go
+++ b/redis/pool_test.go
@@ -92,12 +92,15 @@ func (d *poolDialer) check(message string, p *redis.Pool, dialed, open, inuse in
 		d.t.Errorf("%s: open=%d, want %d", message, d.open, open)
 	}
 
-	if active := p.ActiveCount(); active != open {
-		d.t.Errorf("%s: active=%d, want %d", message, active, open)
+	stats := p.Stats()
+
+	if stats.ActiveCount != open {
+		d.t.Errorf("%s: active=%d, want %d", message, stats.ActiveCount, open)
 	}
-	if idle := p.IdleCount(); idle != open-inuse {
-		d.t.Errorf("%s: idle=%d, want %d", message, idle, open-inuse)
+	if stats.IdleCount != open-inuse {
+		d.t.Errorf("%s: idle=%d, want %d", message, stats.IdleCount, open-inuse)
 	}
+
 	d.mu.Unlock()
 }
 


### PR DESCRIPTION
At the moment ActiveCount & IdleCount methods can return the inconsistent state because between calls new operation can be opened or idle connection can be closed because of IdleTimeout. This PR returns consistent stats.