### PR TITLE
Fixes an issue with int type when using redigo mock

### DIFF
--- a/redis/reply.go
+++ b/redis/reply.go
@@ -203,7 +203,7 @@ func Bool(reply interface{}, err error) (bool, error) {
 		return false, err
 	}
 	switch reply := reply.(type) {
-	case int64:
+	case int, int64:
 		return reply != 0, nil
 	case []byte:
 		return strconv.ParseBool(string(reply))


### PR DESCRIPTION
When using the redigomock package and you want `connection.Do("EXISTS", "test.key")` command to return the reply `0` but redigomock returns `int` instead of `int64`. And `redis.Bool()` is expecting a `int64`.

The workaround is to expect `int64(1)` i.e. `connection.Command(RedisEXISTS, "test.key").Expect(int64(1))`, However, this only works when you want the key to exist and doesn't when the expected is `int64(0)`. It throws the following error:

```bash
redigo: unexpected type for Bool, got type int
```

Here's a reproducible scenario: 

```golang
connection := redigomock.NewConn()
// return key exists
connection.Command(RedisEXISTS, "test.key").Expect(0)
exists, err := redis.Bool(connection.Do("EXISTS", "test.key"))
fmt.Println(exists)
fmt.Println(err)
if err != nil {
	t.Errorf("Exists() = %v, want %v", exists, true)
}
```