### PR TITLE
Add the missing comma in comment(#305).

### DIFF
--- a/redis/pool.go
+++ b/redis/pool.go
@@ -96,7 +96,7 @@ var (
 //        return nil, err
 //      }
 //      return c, nil
-//    }
+//    },
 //  }
 //
 // Use the TestOnBorrow function to check the health of an idle connection


### PR DESCRIPTION
Missing comma in the comment of Pool to show how to use Dial function.

See: [Issue#305](https://github.com/garyburd/redigo/issues/305)

Thanks:-)